### PR TITLE
Serialization fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "rust/examples/pdb-ng/pdb-0.8.0-patched"]
 	path = rust/examples/pdb-ng/pdb-0.8.0-patched
 	url = https://github.com/Vector35/pdb-rs.git
+[submodule "vendor/immer"]
+	path = vendor/immer
+	url = https://github.com/arximboldi/immer.git

--- a/view/sharedcache/CMakeLists.txt
+++ b/view/sharedcache/CMakeLists.txt
@@ -59,7 +59,7 @@ set_target_properties(sharedcache PROPERTIES
         POSITION_INDEPENDENT_CODE ON
         )
 
-target_include_directories(sharedcache PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/workflow)
+target_include_directories(sharedcache PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/workflow  ${BN_API_PATH}/vendor/immer)
 
 target_link_libraries(sharedcache PUBLIC sharedcacheapi binaryninjaapi sharedcachecore sharedcacheworkflow)
 

--- a/view/sharedcache/api/CMakeLists.txt
+++ b/view/sharedcache/api/CMakeLists.txt
@@ -64,7 +64,7 @@ endfunction()
 get_recursive_include_dirs(binaryninjaapi INCLUDES)
 
 target_include_directories(sharedcacheapi
-        PUBLIC ${PROJECT_SOURCE_DIR} ${INCLUDES})
+        PUBLIC ${PROJECT_SOURCE_DIR} ${INCLUDES} ${BN_API_PATH}/vendor/immer)
 
 set_target_properties(sharedcacheapi PROPERTIES
         CXX_STANDARD 17

--- a/view/sharedcache/api/sharedcacheapi.h
+++ b/view/sharedcache/api/sharedcacheapi.h
@@ -257,7 +257,7 @@ namespace SharedCacheAPI {
 		static BNDSCViewLoadProgress GetLoadProgress(Ref<BinaryView> view);
 		static uint64_t FastGetBackingCacheCount(Ref<BinaryView> view);
 
-		bool LoadImageWithInstallName(std::string installName);
+		bool LoadImageWithInstallName(std::string_view installName);
 		bool LoadSectionAtAddress(uint64_t addr);
 		bool LoadImageContainingAddress(uint64_t addr);
 		std::vector<std::string> GetAvailableImages();
@@ -270,7 +270,7 @@ namespace SharedCacheAPI {
 		std::vector<BackingCache> GetBackingCaches();
 		std::vector<DSCImage> GetImages();
 
-		std::optional<SharedCacheMachOHeader> GetMachOHeaderForImage(std::string name);
+		std::optional<SharedCacheMachOHeader> GetMachOHeaderForImage(std::string_view name);
 		std::optional<SharedCacheMachOHeader> GetMachOHeaderForAddress(uint64_t address);
 
 		std::vector<DSCMemoryRegion> GetLoadedMemoryRegions();

--- a/view/sharedcache/core/CMakeLists.txt
+++ b/view/sharedcache/core/CMakeLists.txt
@@ -77,7 +77,7 @@ target_compile_definitions(sharedcachecore PRIVATE ${COMPILE_DEFS})
 
 target_compile_definitions(sharedcachecore PRIVATE SHAREDCACHE_LIBRARY ${COMPILE_DEFS})
 
-target_include_directories(sharedcachecore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${INCLUDES})
+target_include_directories(sharedcachecore PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${INCLUDES} ${BN_API_PATH}/vendor/immer)
 
 set_target_properties(sharedcachecore PROPERTIES
         CXX_STANDARD 17

--- a/view/sharedcache/core/MetadataSerializable.cpp
+++ b/view/sharedcache/core/MetadataSerializable.cpp
@@ -140,6 +140,46 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 		b.emplace_back(i.GetString());
 }
 
+void Deserialize(DeserializationContext& context, std::string_view name, immer::map<uint64_t, std::string>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+		transient.set(i.GetArray()[0].GetUint64(), i.GetArray()[1].GetString());
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::map<uint64_t, uint64_t>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+		transient.set(i.GetArray()[0].GetUint64(), i.GetArray()[1].GetUint64());
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, immer::map<uint64_t, uint64_t>>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		std::string key = i.GetArray()[0].GetString();
+		immer::map_transient<uint64_t, uint64_t> memArray;
+		for (auto& member : i.GetArray()[1].GetArray())
+		{
+			memArray.set(member.GetArray()[0].GetUint64(), member.GetArray()[1].GetUint64());
+		}
+		transient.set(key, std::move(memArray).persistent());
+	}
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, std::string>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+		transient.set(i.GetArray()[0].GetString(), i.GetArray()[1].GetString());
+	b = std::move(transient).persistent();
+}
+
 // Note: This flattens the pair into [first, second.first, second.second] with no nested arrays.
 void Serialize(SerializationContext& context, const std::pair<uint64_t, std::pair<uint64_t, uint64_t>>& value)
 {
@@ -201,6 +241,77 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 		}
 		b.push_back(j);
 	}
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::string>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+		transient.push_back(i.GetString());
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, std::pair<uint64_t, uint64_t>>>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		std::pair<uint64_t, std::pair<uint64_t, uint64_t>> j;
+		j.first = i.GetArray()[0].GetUint64();
+		j.second.first = i.GetArray()[1].GetUint64();
+		j.second.second = i.GetArray()[2].GetUint64();
+		transient.push_back(j);
+	}
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, bool>>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		std::pair<uint64_t, bool> j;
+		j.first = i.GetArray()[0].GetUint64();
+		j.second = i.GetArray()[1].GetBool();
+		transient.push_back(j);
+	}
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<uint64_t>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		transient.push_back(i.GetUint64());
+	}
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, uint64_t>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		transient.set(i.GetArray()[0].GetString(), i.GetArray()[1].GetUint64());
+	}
+	b = std::move(transient).persistent();
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, immer::vector<std::pair<uint64_t, std::string>>>>& b)
+{
+	auto transient = b.transient();
+	for (auto& i : context.doc[name.data()].GetArray())
+	{
+		std::pair<uint64_t, immer::vector_transient<std::pair<uint64_t, std::string>>> j;
+		j.first = i.GetArray()[0].GetUint64();
+		for (auto& k : i.GetArray()[1].GetArray())
+		{
+			j.second.push_back({k.GetArray()[0].GetUint64(), k.GetArray()[1].GetString()});
+		}
+		transient.push_back({j.first, std::move(j.second).persistent()});
+	}
+	b = std::move(transient).persistent();
 }
 
 void Serialize(SerializationContext& context, const mach_header_64& value) {
@@ -425,6 +536,35 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 	}
 }
 
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<section_64>& b)
+{
+	auto bArr = context.doc[name.data()].GetArray();
+	auto transient = b.transient();
+	for (auto& s : bArr)
+	{
+		section_64 sec;
+		auto s2 = s.GetArray();
+		std::string sectNameStr = s2[0].GetString();
+		memset(sec.sectname, 0, 16);
+		memcpy(sec.sectname, sectNameStr.c_str(), sectNameStr.size());
+		std::string segNameStr = s2[1].GetString();
+		memset(sec.segname, 0, 16);
+		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
+		sec.addr = s2[2].GetUint64();
+		sec.size = s2[3].GetUint64();
+		sec.offset = s2[4].GetUint();
+		sec.align = s2[5].GetUint();
+		sec.reloff = s2[6].GetUint();
+		sec.nreloc = s2[7].GetUint();
+		sec.flags = s2[8].GetUint();
+		sec.reserved1 = s2[9].GetUint();
+		sec.reserved2 = s2[10].GetUint();
+		sec.reserved3 = s2[11].GetUint();
+		transient.push_back(std::move(sec));
+	}
+	b = std::move(transient).persistent();
+}
+
 void Serialize(SerializationContext& context, const linkedit_data_command& value)
 {
 	context.writer.StartArray();
@@ -498,6 +638,31 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 	}
 }
 
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<segment_command_64>& b)
+{
+	auto bArr = context.doc[name.data()].GetArray();
+	auto transient = b.transient();
+	for (auto& s : bArr)
+	{
+		segment_command_64 sec;
+		auto s2 = s.GetArray();
+		std::string segNameStr = s2[0].GetString();
+		memset(sec.segname, 0, 16);
+		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
+		sec.vmaddr = s2[1].GetUint64();
+		sec.vmsize = s2[2].GetUint64();
+		sec.fileoff = s2[3].GetUint64();
+		sec.filesize = s2[4].GetUint64();
+		sec.maxprot = s2[5].GetUint();
+		sec.initprot = s2[6].GetUint();
+		sec.nsects = s2[7].GetUint();
+		sec.flags = s2[8].GetUint();
+		transient.push_back(std::move(sec));
+	}
+	b = std::move(transient).persistent();
+}
+
+
 void Serialize(SerializationContext& context, const build_version_command& value)
 {
 	context.writer.StartArray();
@@ -540,6 +705,21 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 		sec.version = s2[1].GetUint();
 		b.push_back(sec);
 	}
+}
+
+void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<build_tool_version>& b)
+{
+	auto bArr = context.doc[name.data()].GetArray();
+	auto transient = b.transient();
+	for (auto& s : bArr)
+	{
+		build_tool_version sec;
+		auto s2 = s.GetArray();
+		sec.tool = s2[0].GetUint();
+		sec.version = s2[1].GetUint();
+		transient.push_back(sec);
+	}
+	b = std::move(transient).persistent();
 }
 
 } // namespace SharedCacheCore

--- a/view/sharedcache/core/MetadataSerializable.cpp
+++ b/view/sharedcache/core/MetadataSerializable.cpp
@@ -2,6 +2,9 @@
 
 namespace SharedCacheCore {
 
+#define DESERIALIZE_FIELD(field, container) \
+	field = container.Get<decltype(field)>();
+
 void Serialize(SerializationContext& context, std::string_view str) {
 	context.writer.String(str.data(), str.length());
 }
@@ -180,24 +183,14 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 	b = std::move(transient).persistent();
 }
 
-// Note: This flattens the pair into [first, second.first, second.second] with no nested arrays.
-void Serialize(SerializationContext& context, const std::pair<uint64_t, std::pair<uint64_t, uint64_t>>& value)
-{
-	context.writer.StartArray();
-	Serialize(context, value.first);
-	Serialize(context, value.second.first);
-	Serialize(context, value.second.second);
-	context.writer.EndArray();
-}
-
 void Deserialize(DeserializationContext& context, std::string_view name, std::vector<std::pair<uint64_t, std::pair<uint64_t, uint64_t>>>& b)
 {
 	for (auto& i : context.doc[name.data()].GetArray())
 	{
 		std::pair<uint64_t, std::pair<uint64_t, uint64_t>> j;
-		j.first = i.GetArray()[0].GetUint64();
-		j.second.first = i.GetArray()[1].GetUint64();
-		j.second.second = i.GetArray()[2].GetUint64();
+		DESERIALIZE_FIELD(j.first, i.GetArray()[0])
+		DESERIALIZE_FIELD(j.second.first, i.GetArray()[1].GetArray()[0])
+		DESERIALIZE_FIELD(j.second.second, i.GetArray()[1].GetArray()[1])
 		b.push_back(j);
 	}
 }
@@ -207,8 +200,8 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 	for (auto& i : context.doc[name.data()].GetArray())
 	{
 		std::pair<uint64_t, bool> j;
-		j.first = i.GetArray()[0].GetUint64();
-		j.second = i.GetArray()[1].GetBool();
+		DESERIALIZE_FIELD(j.first, i.GetArray()[0])
+		DESERIALIZE_FIELD(j.second, i.GetArray()[1])
 		b.push_back(j);
 	}
 }
@@ -257,9 +250,9 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 	for (auto& i : context.doc[name.data()].GetArray())
 	{
 		std::pair<uint64_t, std::pair<uint64_t, uint64_t>> j;
-		j.first = i.GetArray()[0].GetUint64();
-		j.second.first = i.GetArray()[1].GetUint64();
-		j.second.second = i.GetArray()[2].GetUint64();
+		DESERIALIZE_FIELD(j.first, i.GetArray()[0])
+		DESERIALIZE_FIELD(j.second.first, i.GetArray()[1].GetArray()[0])
+		DESERIALIZE_FIELD(j.second.second, i.GetArray()[1].GetArray()[1])
 		transient.push_back(j);
 	}
 	b = std::move(transient).persistent();
@@ -271,8 +264,8 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 	for (auto& i : context.doc[name.data()].GetArray())
 	{
 		std::pair<uint64_t, bool> j;
-		j.first = i.GetArray()[0].GetUint64();
-		j.second = i.GetArray()[1].GetBool();
+		DESERIALIZE_FIELD(j.first, i.GetArray()[0])
+		DESERIALIZE_FIELD(j.second, i.GetArray()[1])
 		transient.push_back(j);
 	}
 	b = std::move(transient).persistent();
@@ -330,14 +323,14 @@ void Serialize(SerializationContext& context, const mach_header_64& value) {
 void Deserialize(DeserializationContext& context, std::string_view name, mach_header_64& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.magic = bArr[0].GetUint();
-	b.cputype = bArr[1].GetUint();
-	b.cpusubtype = bArr[2].GetUint();
-	b.filetype = bArr[3].GetUint();
-	b.ncmds = bArr[4].GetUint();
-	b.sizeofcmds = bArr[5].GetUint();
-	b.flags = bArr[6].GetUint();
-	b.reserved = bArr[7].GetUint();
+	DESERIALIZE_FIELD(b.magic, bArr[0])
+	DESERIALIZE_FIELD(b.cputype, bArr[1])
+	DESERIALIZE_FIELD(b.cpusubtype, bArr[2])
+	DESERIALIZE_FIELD(b.filetype, bArr[3])
+	DESERIALIZE_FIELD(b.ncmds, bArr[4])
+	DESERIALIZE_FIELD(b.sizeofcmds, bArr[5])
+	DESERIALIZE_FIELD(b.flags, bArr[6])
+	DESERIALIZE_FIELD(b.reserved, bArr[7])
 }
 
 void Serialize(SerializationContext& context, const symtab_command& value)
@@ -355,12 +348,12 @@ void Serialize(SerializationContext& context, const symtab_command& value)
 void Deserialize(DeserializationContext& context, std::string_view name, symtab_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.symoff = bArr[2].GetUint();
-	b.nsyms = bArr[3].GetUint();
-	b.stroff = bArr[4].GetUint();
-	b.strsize = bArr[5].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.symoff, bArr[2])
+	DESERIALIZE_FIELD(b.nsyms, bArr[3])
+	DESERIALIZE_FIELD(b.stroff, bArr[4])
+	DESERIALIZE_FIELD(b.strsize, bArr[5])
 }
 
 void Serialize(SerializationContext& context, const dysymtab_command& value)
@@ -392,26 +385,26 @@ void Serialize(SerializationContext& context, const dysymtab_command& value)
 void Deserialize(DeserializationContext& context, std::string_view name, dysymtab_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.ilocalsym = bArr[2].GetUint();
-	b.nlocalsym = bArr[3].GetUint();
-	b.iextdefsym = bArr[4].GetUint();
-	b.nextdefsym = bArr[5].GetUint();
-	b.iundefsym = bArr[6].GetUint();
-	b.nundefsym = bArr[7].GetUint();
-	b.tocoff = bArr[8].GetUint();
-	b.ntoc = bArr[9].GetUint();
-	b.modtaboff = bArr[10].GetUint();
-	b.nmodtab = bArr[11].GetUint();
-	b.extrefsymoff = bArr[12].GetUint();
-	b.nextrefsyms = bArr[13].GetUint();
-	b.indirectsymoff = bArr[14].GetUint();
-	b.nindirectsyms = bArr[15].GetUint();
-	b.extreloff = bArr[16].GetUint();
-	b.nextrel = bArr[17].GetUint();
-	b.locreloff = bArr[18].GetUint();
-	b.nlocrel = bArr[19].GetUint();
+	b.cmd = bArr[0].Get<decltype(b.cmd)>();
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.ilocalsym, bArr[2])
+	DESERIALIZE_FIELD(b.nlocalsym, bArr[3])
+	DESERIALIZE_FIELD(b.iextdefsym, bArr[4])
+	DESERIALIZE_FIELD(b.nextdefsym, bArr[5])
+	DESERIALIZE_FIELD(b.iundefsym, bArr[6])
+	DESERIALIZE_FIELD(b.nundefsym, bArr[7])
+	DESERIALIZE_FIELD(b.tocoff, bArr[8])
+	DESERIALIZE_FIELD(b.ntoc, bArr[9])
+	DESERIALIZE_FIELD(b.modtaboff, bArr[10])
+	DESERIALIZE_FIELD(b.nmodtab, bArr[11])
+	DESERIALIZE_FIELD(b.extrefsymoff, bArr[12])
+	DESERIALIZE_FIELD(b.nextrefsyms, bArr[13])
+	DESERIALIZE_FIELD(b.indirectsymoff, bArr[14])
+	DESERIALIZE_FIELD(b.nindirectsyms, bArr[15])
+	DESERIALIZE_FIELD(b.extreloff, bArr[16])
+	DESERIALIZE_FIELD(b.nextrel, bArr[17])
+	DESERIALIZE_FIELD(b.locreloff, bArr[18])
+	DESERIALIZE_FIELD(b.nlocrel, bArr[19])
 }
 
 void Serialize(SerializationContext& context, const dyld_info_command& value)
@@ -435,18 +428,18 @@ void Serialize(SerializationContext& context, const dyld_info_command& value)
 void Deserialize(DeserializationContext& context, std::string_view name, dyld_info_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.rebase_off = bArr[2].GetUint();
-	b.rebase_size = bArr[3].GetUint();
-	b.bind_off = bArr[4].GetUint();
-	b.bind_size = bArr[5].GetUint();
-	b.weak_bind_off = bArr[6].GetUint();
-	b.weak_bind_size = bArr[7].GetUint();
-	b.lazy_bind_off = bArr[8].GetUint();
-	b.lazy_bind_size = bArr[9].GetUint();
-	b.export_off = bArr[10].GetUint();
-	b.export_size = bArr[11].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.rebase_off, bArr[2])
+	DESERIALIZE_FIELD(b.rebase_size, bArr[3])
+	DESERIALIZE_FIELD(b.bind_off, bArr[4])
+	DESERIALIZE_FIELD(b.bind_size, bArr[5])
+	DESERIALIZE_FIELD(b.weak_bind_off, bArr[6])
+	DESERIALIZE_FIELD(b.weak_bind_size, bArr[7])
+	DESERIALIZE_FIELD(b.lazy_bind_off, bArr[8])
+	DESERIALIZE_FIELD(b.lazy_bind_size, bArr[9])
+	DESERIALIZE_FIELD(b.export_off, bArr[10])
+	DESERIALIZE_FIELD(b.export_size, bArr[11])
 }
 
 void Serialize(SerializationContext& context, const routines_command_64& value)
@@ -462,10 +455,10 @@ void Serialize(SerializationContext& context, const routines_command_64& value)
 void Deserialize(DeserializationContext& context, std::string_view name, routines_command_64& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.init_address = bArr[2].GetUint();
-	b.init_module = bArr[3].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.init_address, bArr[2])
+	DESERIALIZE_FIELD(b.init_module, bArr[3])
 }
 
 void Serialize(SerializationContext& context, const function_starts_command& value)
@@ -481,10 +474,10 @@ void Serialize(SerializationContext& context, const function_starts_command& val
 void Deserialize(DeserializationContext& context, std::string_view name, function_starts_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.funcoff = bArr[2].GetUint();
-	b.funcsize = bArr[3].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.funcoff, bArr[2])
+	DESERIALIZE_FIELD(b.funcsize, bArr[3])
 }
 
 void Serialize(SerializationContext& context, const section_64& value)
@@ -522,16 +515,16 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 		std::string segNameStr = s2[1].GetString();
 		memset(sec.segname, 0, 16);
 		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
-		sec.addr = s2[2].GetUint64();
-		sec.size = s2[3].GetUint64();
-		sec.offset = s2[4].GetUint();
-		sec.align = s2[5].GetUint();
-		sec.reloff = s2[6].GetUint();
-		sec.nreloc = s2[7].GetUint();
-		sec.flags = s2[8].GetUint();
-		sec.reserved1 = s2[9].GetUint();
-		sec.reserved2 = s2[10].GetUint();
-		sec.reserved3 = s2[11].GetUint();
+		DESERIALIZE_FIELD(sec.addr, s2[2])
+		DESERIALIZE_FIELD(sec.size, s2[3])
+		DESERIALIZE_FIELD(sec.offset, s2[4])
+		DESERIALIZE_FIELD(sec.align, s2[5])
+		DESERIALIZE_FIELD(sec.reloff, s2[6])
+		DESERIALIZE_FIELD(sec.nreloc, s2[7])
+		DESERIALIZE_FIELD(sec.flags, s2[8])
+		DESERIALIZE_FIELD(sec.reserved1, s2[9])
+		DESERIALIZE_FIELD(sec.reserved2, s2[10])
+		DESERIALIZE_FIELD(sec.reserved3, s2[11])
 		b.push_back(std::move(sec));
 	}
 }
@@ -550,16 +543,16 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 		std::string segNameStr = s2[1].GetString();
 		memset(sec.segname, 0, 16);
 		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
-		sec.addr = s2[2].GetUint64();
-		sec.size = s2[3].GetUint64();
-		sec.offset = s2[4].GetUint();
-		sec.align = s2[5].GetUint();
-		sec.reloff = s2[6].GetUint();
-		sec.nreloc = s2[7].GetUint();
-		sec.flags = s2[8].GetUint();
-		sec.reserved1 = s2[9].GetUint();
-		sec.reserved2 = s2[10].GetUint();
-		sec.reserved3 = s2[11].GetUint();
+		DESERIALIZE_FIELD(sec.addr, s2[2])
+		DESERIALIZE_FIELD(sec.size, s2[3])
+		DESERIALIZE_FIELD(sec.offset, s2[4])
+		DESERIALIZE_FIELD(sec.align, s2[5])
+		DESERIALIZE_FIELD(sec.reloff, s2[6])
+		DESERIALIZE_FIELD(sec.nreloc, s2[7])
+		DESERIALIZE_FIELD(sec.flags, s2[8])
+		DESERIALIZE_FIELD(sec.reserved1, s2[9])
+		DESERIALIZE_FIELD(sec.reserved2, s2[10])
+		DESERIALIZE_FIELD(sec.reserved3, s2[11])
 		transient.push_back(std::move(sec));
 	}
 	b = std::move(transient).persistent();
@@ -578,10 +571,10 @@ void Serialize(SerializationContext& context, const linkedit_data_command& value
 void Deserialize(DeserializationContext& context, std::string_view name, linkedit_data_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.dataoff = bArr[2].GetUint();
-	b.datasize = bArr[3].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.dataoff, bArr[2])
+	DESERIALIZE_FIELD(b.datasize, bArr[3])
 }
 
 void Serialize(SerializationContext& context, const segment_command_64& value)
@@ -606,14 +599,14 @@ void Deserialize(DeserializationContext& context, std::string_view name, segment
 	std::string segNameStr = bArr[0].GetString();
 	memset(b.segname, 0, 16);
 	memcpy(b.segname, segNameStr.c_str(), segNameStr.size());
-	b.vmaddr = bArr[1].GetUint64();
-	b.vmsize = bArr[2].GetUint64();
-	b.fileoff = bArr[3].GetUint64();
-	b.filesize = bArr[4].GetUint64();
-	b.maxprot = bArr[5].GetUint();
-	b.initprot = bArr[6].GetUint();
-	b.nsects = bArr[7].GetUint();
-	b.flags = bArr[8].GetUint();
+	DESERIALIZE_FIELD(b.vmaddr, bArr[1])
+	DESERIALIZE_FIELD(b.vmsize, bArr[2])
+	DESERIALIZE_FIELD(b.fileoff, bArr[3])
+	DESERIALIZE_FIELD(b.filesize, bArr[4])
+	DESERIALIZE_FIELD(b.maxprot, bArr[5])
+	DESERIALIZE_FIELD(b.initprot, bArr[6])
+	DESERIALIZE_FIELD(b.nsects, bArr[7])
+	DESERIALIZE_FIELD(b.flags, bArr[8])
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, std::vector<segment_command_64>& b)
@@ -626,14 +619,14 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 		std::string segNameStr = s2[0].GetString();
 		memset(sec.segname, 0, 16);
 		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
-		sec.vmaddr = s2[1].GetUint64();
-		sec.vmsize = s2[2].GetUint64();
-		sec.fileoff = s2[3].GetUint64();
-		sec.filesize = s2[4].GetUint64();
-		sec.maxprot = s2[5].GetUint();
-		sec.initprot = s2[6].GetUint();
-		sec.nsects = s2[7].GetUint();
-		sec.flags = s2[8].GetUint();
+		DESERIALIZE_FIELD(sec.vmaddr, s2[1])
+		DESERIALIZE_FIELD(sec.vmsize, s2[2])
+		DESERIALIZE_FIELD(sec.fileoff, s2[3])
+		DESERIALIZE_FIELD(sec.filesize, s2[4])
+		DESERIALIZE_FIELD(sec.maxprot, s2[5])
+		DESERIALIZE_FIELD(sec.initprot, s2[6])
+		DESERIALIZE_FIELD(sec.nsects, s2[7])
+		DESERIALIZE_FIELD(sec.flags, s2[8])
 		b.push_back(std::move(sec));
 	}
 }
@@ -649,14 +642,14 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 		std::string segNameStr = s2[0].GetString();
 		memset(sec.segname, 0, 16);
 		memcpy(sec.segname, segNameStr.c_str(), segNameStr.size());
-		sec.vmaddr = s2[1].GetUint64();
-		sec.vmsize = s2[2].GetUint64();
-		sec.fileoff = s2[3].GetUint64();
-		sec.filesize = s2[4].GetUint64();
-		sec.maxprot = s2[5].GetUint();
-		sec.initprot = s2[6].GetUint();
-		sec.nsects = s2[7].GetUint();
-		sec.flags = s2[8].GetUint();
+		DESERIALIZE_FIELD(sec.vmaddr, s2[1])
+		DESERIALIZE_FIELD(sec.vmsize, s2[2])
+		DESERIALIZE_FIELD(sec.fileoff, s2[3])
+		DESERIALIZE_FIELD(sec.filesize, s2[4])
+		DESERIALIZE_FIELD(sec.maxprot, s2[5])
+		DESERIALIZE_FIELD(sec.initprot, s2[6])
+		DESERIALIZE_FIELD(sec.nsects, s2[7])
+		DESERIALIZE_FIELD(sec.flags, s2[8])
 		transient.push_back(std::move(sec));
 	}
 	b = std::move(transient).persistent();
@@ -678,12 +671,12 @@ void Serialize(SerializationContext& context, const build_version_command& value
 void Deserialize(DeserializationContext& context, std::string_view name, build_version_command& b)
 {
 	auto bArr = context.doc[name.data()].GetArray();
-	b.cmd = bArr[0].GetUint();
-	b.cmdsize = bArr[1].GetUint();
-	b.platform = bArr[2].GetUint();
-	b.minos = bArr[3].GetUint();
-	b.sdk = bArr[4].GetUint();
-	b.ntools = bArr[5].GetUint();
+	DESERIALIZE_FIELD(b.cmd, bArr[0])
+	DESERIALIZE_FIELD(b.cmdsize, bArr[1])
+	DESERIALIZE_FIELD(b.platform, bArr[2])
+	DESERIALIZE_FIELD(b.minos, bArr[3])
+	DESERIALIZE_FIELD(b.sdk, bArr[4])
+	DESERIALIZE_FIELD(b.ntools, bArr[5])
 }
 
 void Serialize(SerializationContext& context, const build_tool_version& value)
@@ -701,8 +694,8 @@ void Deserialize(DeserializationContext& context, std::string_view name, std::ve
 	{
 		build_tool_version sec;
 		auto s2 = s.GetArray();
-		sec.tool = s2[0].GetUint();
-		sec.version = s2[1].GetUint();
+		DESERIALIZE_FIELD(sec.tool, s2[0])
+		DESERIALIZE_FIELD(sec.version, s2[1])
 		b.push_back(sec);
 	}
 }
@@ -715,11 +708,13 @@ void Deserialize(DeserializationContext& context, std::string_view name, immer::
 	{
 		build_tool_version sec;
 		auto s2 = s.GetArray();
-		sec.tool = s2[0].GetUint();
-		sec.version = s2[1].GetUint();
+		DESERIALIZE_FIELD(sec.tool, s2[0])
+		DESERIALIZE_FIELD(sec.version, s2[1])
 		transient.push_back(sec);
 	}
 	b = std::move(transient).persistent();
 }
+
+#undef DESERIALIZE_FIELD
 
 } // namespace SharedCacheCore

--- a/view/sharedcache/core/MetadataSerializable.cpp
+++ b/view/sharedcache/core/MetadataSerializable.cpp
@@ -53,17 +53,17 @@ void Deserialize(DeserializationContext& context, std::string_view name, bool& b
 
 void Deserialize(DeserializationContext& context, std::string_view name, uint8_t& b)
 {
-	b = static_cast<uint8_t>(context.doc[name.data()].GetUint64());
+	b = static_cast<uint8_t>(context.doc[name.data()].GetUint());
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, uint16_t& b)
 {
-	b = static_cast<uint16_t>(context.doc[name.data()].GetUint64());
+	b = static_cast<uint16_t>(context.doc[name.data()].GetUint());
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, uint32_t& b)
 {
-	b = static_cast<uint32_t>(context.doc[name.data()].GetUint64());
+	b = static_cast<uint32_t>(context.doc[name.data()].GetUint());
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, uint64_t& b)
@@ -73,12 +73,12 @@ void Deserialize(DeserializationContext& context, std::string_view name, uint64_
 
 void Deserialize(DeserializationContext& context, std::string_view name, int8_t& b)
 {
-	b = context.doc[name.data()].GetInt64();
+	b = context.doc[name.data()].GetInt();
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, int16_t& b)
 {
-	b = context.doc[name.data()].GetInt64();
+	b = context.doc[name.data()].GetInt();
 }
 
 void Deserialize(DeserializationContext& context, std::string_view name, int32_t& b)

--- a/view/sharedcache/core/MetadataSerializable.hpp
+++ b/view/sharedcache/core/MetadataSerializable.hpp
@@ -40,6 +40,10 @@
 #include "rapidjson/prettywriter.h"
 #include "../api/sharedcachecore.h"
 #include "view/macho/machoview.h"
+#include "immer/map.hpp" 
+#include "immer/vector.hpp" 
+#include "immer/vector_transient.hpp" 
+#include "immer/map_transient.hpp" 
 
 #ifndef SHAREDCACHE_CORE_METADATASERIALIZABLE_HPP
 #define SHAREDCACHE_CORE_METADATASERIALIZABLE_HPP
@@ -191,6 +195,29 @@ void Serialize(SerializationContext& context, const std::vector<T>& values)
 	context.writer.EndArray();
 }
 
+template <typename K, typename V>
+void Serialize(SerializationContext& context, const immer::map<K, V>& value)
+{
+	context.writer.StartArray();
+	for (auto& pair : value)
+	{
+		Serialize(context, pair);
+	}
+	context.writer.EndArray();
+}
+
+template <typename T>
+void Serialize(SerializationContext& context, const immer::vector<T>& values)
+{
+	context.writer.StartArray();
+	for (const auto& value : values)
+	{
+		Serialize(context, value);
+	}
+	context.writer.EndArray();
+}
+
+
 SHAREDCACHE_FFI_API void Serialize(SerializationContext& context, const char*);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext& context, bool b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, bool& b);
@@ -223,6 +250,16 @@ SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::strin
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, std::vector<uint64_t>& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, std::unordered_map<std::string, uint64_t>& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, std::vector<std::pair<uint64_t, std::vector<std::pair<uint64_t, std::string>>>>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::map<uint64_t, std::string>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::map<uint64_t, uint64_t>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, immer::map<uint64_t, uint64_t>>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, std::string>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::string>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, std::pair<uint64_t, uint64_t>>>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, bool>>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<uint64_t>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::map<std::string, uint64_t>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext& context, std::string_view name, immer::vector<std::pair<uint64_t, immer::vector<std::pair<uint64_t, std::string>>>>& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const mach_header_64& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, mach_header_64& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const symtab_command& b);
@@ -237,15 +274,18 @@ SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const function_starts_
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, function_starts_command& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const section_64& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, std::vector<section_64>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, immer::vector<section_64>& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const linkedit_data_command& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, linkedit_data_command& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const segment_command_64& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, segment_command_64& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, std::vector<segment_command_64>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, immer::vector<segment_command_64>& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const build_version_command& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, build_version_command& b);
 SHAREDCACHE_FFI_API void Serialize(SerializationContext&, const build_tool_version& b);
 SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, std::vector<build_tool_version>& b);
+SHAREDCACHE_FFI_API void Deserialize(DeserializationContext&, std::string_view name, immer::vector<build_tool_version>& b);
 
 } // namespace SharedCacheCore
 

--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -53,30 +53,33 @@ int count_trailing_zeros(uint64_t value) {
 }
 #endif
 
-struct ViewStateCacheStore {
-	SharedCache::SharedCacheFormat m_cacheFormat;
+struct SharedCache::State
+{
+	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>>>
+		exportInfos;
+	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>>>
+		symbolInfos;
 
-	DSCViewState m_viewState;
+	std::unordered_map<std::string, uint64_t> imageStarts;
+	std::unordered_map<uint64_t, SharedCacheMachOHeader> headers;
 
-	std::unordered_map<std::string, uint64_t> m_imageStarts;
-	std::unordered_map<uint64_t, SharedCacheMachOHeader> m_headers;
+	std::vector<CacheImage> images;
 
-	std::vector<CacheImage> m_images;
-	std::vector<MemoryRegion> m_regionsMappedIntoMemory;
+	std::vector<MemoryRegion> regionsMappedIntoMemory;
 
-	std::vector<BackingCache> m_backingCaches;
-	std::vector<MemoryRegion> m_stubIslandRegions; // TODO honestly both of these should be refactored into nonImageRegions. :p
-	std::vector<MemoryRegion> m_dyldDataRegions;
-	std::vector<MemoryRegion> m_nonImageRegions;
+	std::vector<BackingCache> backingCaches;
 
-	std::string m_baseFilePath;
+	std::vector<MemoryRegion> stubIslandRegions;  // TODO honestly both of these should be refactored into nonImageRegions. :p
+	std::vector<MemoryRegion> dyldDataRegions;
+	std::vector<MemoryRegion> nonImageRegions;
 
-	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>>> m_exportInfos;
-	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>>> m_symbolInfos;
+	std::string baseFilePath;
+	SharedCacheFormat cacheFormat;
+	DSCViewState viewState = DSCViewStateUnloaded;
 };
 
 static std::recursive_mutex viewStateMutex;
-static std::unordered_map<uint64_t, ViewStateCacheStore> viewStateCache;
+static std::unordered_map<uint64_t, std::shared_ptr<struct SharedCache::State>> viewStateCache;
 
 std::mutex progressMutex;
 std::unordered_map<uint64_t, BNDSCViewLoadProgress> progressMap;
@@ -221,7 +224,9 @@ void SharedCache::PerformInitialLoad()
 	progressMap[m_dscView->GetFile()->GetSessionId()] = LoadProgressLoadingCaches;
 	progressMutex.unlock();
 
-	m_baseFilePath = path;
+	WillMutateState();
+
+	MutableState().baseFilePath = path;
 
 	DataBuffer sig = baseFile->ReadBuffer(0, 4);
 	if (sig.GetLength() != 4)
@@ -230,14 +235,14 @@ void SharedCache::PerformInitialLoad()
 	if (strncmp(magic, "dyld", 4) != 0)
 		abort();
 
-	m_cacheFormat = RegularCacheFormat;
+	MutableState().cacheFormat = RegularCacheFormat;
 
 	dyld_cache_header primaryCacheHeader {};
 	size_t header_size = baseFile->ReadUInt32(16);
 	baseFile->Read(&primaryCacheHeader, 0, std::min(header_size, sizeof(dyld_cache_header)));
 
 	if (primaryCacheHeader.imagesCountOld != 0)
-		m_cacheFormat = RegularCacheFormat;
+		MutableState().cacheFormat = RegularCacheFormat;
 
 	size_t subCacheOff = offsetof(struct dyld_cache_header, subCacheArrayOffset);
 	size_t headerEnd = primaryCacheHeader.mappingOffset;
@@ -246,15 +251,15 @@ void SharedCache::PerformInitialLoad()
 		if (primaryCacheHeader.cacheType != 2)
 		{
 			if (std::filesystem::exists(ResolveFilePath(m_dscView, baseFile->Path() + ".01")))
-				m_cacheFormat = LargeCacheFormat;
+				MutableState().cacheFormat = LargeCacheFormat;
 			else
-				m_cacheFormat = SplitCacheFormat;
+				MutableState().cacheFormat = SplitCacheFormat;
 		}
 		else
-			m_cacheFormat = iOS16CacheFormat;
+			MutableState().cacheFormat = iOS16CacheFormat;
 	}
 
-	switch (m_cacheFormat)
+	switch (State().cacheFormat)
 	{
 	case RegularCacheFormat:
 	{
@@ -272,7 +277,7 @@ void SharedCache::PerformInitialLoad()
 			mapRawToAddrAndSize.second.second = mapping.size;
 			cache.mappings.push_back(mapRawToAddrAndSize);
 		}
-		m_backingCaches.push_back(cache);
+		MutableState().backingCaches.push_back(std::move(cache));
 
 		dyld_cache_image_info img {};
 
@@ -280,7 +285,7 @@ void SharedCache::PerformInitialLoad()
 		{
 			baseFile->Read(&img, primaryCacheHeader.imagesOffsetOld + (i * sizeof(img)), sizeof(img));
 			auto iname = baseFile->ReadNullTermString(img.pathFileOffset);
-			m_imageStarts[iname] = img.address;
+			MutableState().imageStarts[iname] = img.address;
 		}
 
 		m_logger->LogInfo("Found %d images in the shared cache", primaryCacheHeader.imagesCountOld);
@@ -312,7 +317,7 @@ void SharedCache::PerformInitialLoad()
 						std::string segNameStr = std::string(segName);
 						stubIslandRegion.prettyName = "dyld_shared_cache_branch_islands_" + std::to_string(i) + "::" + segNameStr;
 						stubIslandRegion.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable | BNSegmentFlag::SegmentExecutable);
-						m_stubIslandRegions.push_back(stubIslandRegion);
+						MutableState().stubIslandRegions.push_back(std::move(stubIslandRegion));
 					}
 				}
 			}
@@ -338,9 +343,9 @@ void SharedCache::PerformInitialLoad()
 			mapRawToAddrAndSize.first = mapping.fileOffset;
 			mapRawToAddrAndSize.second.first = mapping.address;
 			mapRawToAddrAndSize.second.second = mapping.size;
-			cache.mappings.push_back(mapRawToAddrAndSize);
+			cache.mappings.push_back(std::move(mapRawToAddrAndSize));
 		}
-		m_backingCaches.push_back(cache);
+		MutableState().backingCaches.push_back(std::move(cache));
 
 		dyld_cache_image_info img {};
 
@@ -348,7 +353,7 @@ void SharedCache::PerformInitialLoad()
 		{
 			baseFile->Read(&img, primaryCacheHeader.imagesOffset + (i * sizeof(img)), sizeof(img));
 			auto iname = baseFile->ReadNullTermString(img.pathFileOffset);
-			m_imageStarts[iname] = img.address;
+			MutableState().imageStarts[iname] = img.address;
 		}
 
 		if (primaryCacheHeader.branchPoolsCount)
@@ -356,7 +361,8 @@ void SharedCache::PerformInitialLoad()
 			std::vector<uint64_t> pool {};
 			for (size_t i = 0; i < primaryCacheHeader.branchPoolsCount; i++)
 			{
-				m_imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] = baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
+				MutableState().imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] =
+					baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
 			}
 		}
 		std::string mainFileName = base_name(path);
@@ -413,7 +419,7 @@ void SharedCache::PerformInitialLoad()
 				mapRawToAddrAndSize.first = subCacheMapping.fileOffset;
 				mapRawToAddrAndSize.second.first = subCacheMapping.address;
 				mapRawToAddrAndSize.second.second = subCacheMapping.size;
-				subCache.mappings.push_back(mapRawToAddrAndSize);
+				subCache.mappings.push_back(std::move(mapRawToAddrAndSize));
 			}
 
 			if (subCacheHeader.mappingCount == 1 && subCacheHeader.imagesCountOld == 0 && subCacheHeader.imagesCount == 0
@@ -427,10 +433,10 @@ void SharedCache::PerformInitialLoad()
 				stubIslandRegion.size = size;
 				stubIslandRegion.prettyName = subCacheFilename + "::_stubs";
 				stubIslandRegion.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable | BNSegmentFlag::SegmentExecutable);
-				m_stubIslandRegions.push_back(stubIslandRegion);
+				MutableState().stubIslandRegions.push_back(std::move(stubIslandRegion));
 			}
 
-			m_backingCaches.push_back(subCache);
+			MutableState().backingCaches.push_back(std::move(subCache));
 		}
 		break;
 	}
@@ -449,9 +455,9 @@ void SharedCache::PerformInitialLoad()
 			mapRawToAddrAndSize.first = mapping.fileOffset;
 			mapRawToAddrAndSize.second.first = mapping.address;
 			mapRawToAddrAndSize.second.second = mapping.size;
-			cache.mappings.push_back(mapRawToAddrAndSize);
+			cache.mappings.push_back(std::move(mapRawToAddrAndSize));
 		}
-		m_backingCaches.push_back(cache);
+		MutableState().backingCaches.push_back(std::move(cache));
 
 		dyld_cache_image_info img {};
 
@@ -459,7 +465,7 @@ void SharedCache::PerformInitialLoad()
 		{
 			baseFile->Read(&img, primaryCacheHeader.imagesOffset + (i * sizeof(img)), sizeof(img));
 			auto iname = baseFile->ReadNullTermString(img.pathFileOffset);
-			m_imageStarts[iname] = img.address;
+			MutableState().imageStarts[iname] = img.address;
 		}
 
 		if (primaryCacheHeader.branchPoolsCount)
@@ -467,7 +473,8 @@ void SharedCache::PerformInitialLoad()
 			std::vector<uint64_t> pool {};
 			for (size_t i = 0; i < primaryCacheHeader.branchPoolsCount; i++)
 			{
-				m_imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] = baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
+				MutableState().imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] =
+					baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
 			}
 		}
 
@@ -508,10 +515,10 @@ void SharedCache::PerformInitialLoad()
 				mapRawToAddrAndSize.first = subCacheMapping.fileOffset;
 				mapRawToAddrAndSize.second.first = subCacheMapping.address;
 				mapRawToAddrAndSize.second.second = subCacheMapping.size;
-				subCache.mappings.push_back(mapRawToAddrAndSize);
+				subCache.mappings.push_back(std::move(mapRawToAddrAndSize));
 			}
 
-			m_backingCaches.push_back(subCache);
+			MutableState().backingCaches.push_back(std::move(subCache));
 
 			if (subCacheHeader.mappingCount == 1 && subCacheHeader.imagesCountOld == 0 && subCacheHeader.imagesCount == 0
 				&& subCacheHeader.imagesTextOffset == 0)
@@ -524,7 +531,7 @@ void SharedCache::PerformInitialLoad()
 				stubIslandRegion.size = size;
 				stubIslandRegion.prettyName = subCacheFilename + "::_stubs";
 				stubIslandRegion.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable | BNSegmentFlag::SegmentExecutable);
-				m_stubIslandRegions.push_back(stubIslandRegion);
+				MutableState().stubIslandRegions.push_back(std::move(stubIslandRegion));
 			}
 		}
 
@@ -554,10 +561,10 @@ void SharedCache::PerformInitialLoad()
 			mapRawToAddrAndSize.first = subCacheMapping.fileOffset;
 			mapRawToAddrAndSize.second.first = subCacheMapping.address;
 			mapRawToAddrAndSize.second.second = subCacheMapping.size;
-			subCache.mappings.push_back(mapRawToAddrAndSize);
+			subCache.mappings.push_back(std::move(mapRawToAddrAndSize));
 		}
 
-		m_backingCaches.push_back(subCache);
+		MutableState().backingCaches.push_back(std::move(subCache));
 		break;
 	}
 	case iOS16CacheFormat:
@@ -575,10 +582,10 @@ void SharedCache::PerformInitialLoad()
 			mapRawToAddrAndSize.first = mapping.fileOffset;
 			mapRawToAddrAndSize.second.first = mapping.address;
 			mapRawToAddrAndSize.second.second = mapping.size;
-			cache.mappings.push_back(mapRawToAddrAndSize);
+			cache.mappings.push_back(std::move(mapRawToAddrAndSize));
 		}
 
-		m_backingCaches.push_back(cache);
+		MutableState().backingCaches.push_back(std::move(cache));
 
 		dyld_cache_image_info img {};
 
@@ -586,7 +593,7 @@ void SharedCache::PerformInitialLoad()
 		{
 			baseFile->Read(&img, primaryCacheHeader.imagesOffset + (i * sizeof(img)), sizeof(img));
 			auto iname = baseFile->ReadNullTermString(img.pathFileOffset);
-			m_imageStarts[iname] = img.address;
+			MutableState().imageStarts[iname] = img.address;
 		}
 
 		if (primaryCacheHeader.branchPoolsCount)
@@ -594,7 +601,8 @@ void SharedCache::PerformInitialLoad()
 			std::vector<uint64_t> pool {};
 			for (size_t i = 0; i < primaryCacheHeader.branchPoolsCount; i++)
 			{
-				m_imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] = baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
+				MutableState().imageStarts["dyld_shared_cache_branch_islands_" + std::to_string(i)] =
+					baseFile->ReadULong(primaryCacheHeader.branchPoolsOffset + (i * m_dscView->GetAddressSize()));
 			}
 		}
 
@@ -657,7 +665,7 @@ void SharedCache::PerformInitialLoad()
 				mapRawToAddrAndSize.first = subCacheMapping.fileOffset;
 				mapRawToAddrAndSize.second.first = subCacheMapping.address;
 				mapRawToAddrAndSize.second.second = subCacheMapping.size;
-				subCache.mappings.push_back(mapRawToAddrAndSize);
+				subCache.mappings.push_back(std::move(mapRawToAddrAndSize));
 
 				if (subCachePath.find(".dylddata") != std::string::npos)
 				{
@@ -669,11 +677,11 @@ void SharedCache::PerformInitialLoad()
 					dyldDataRegion.size = size;
 					dyldDataRegion.prettyName = subCacheFilename + "::_data" + std::to_string(j);
 					dyldDataRegion.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable);
-					m_dyldDataRegions.push_back(dyldDataRegion);
+					MutableState().dyldDataRegions.push_back(std::move(dyldDataRegion));
 				}
 			}
 
-			m_backingCaches.push_back(subCache);
+			MutableState().backingCaches.push_back(std::move(subCache));
 
 			if (subCacheHeader.mappingCount == 1 && subCacheHeader.imagesCountOld == 0 && subCacheHeader.imagesCount == 0
 				&& subCacheHeader.imagesTextOffset == 0)
@@ -686,7 +694,7 @@ void SharedCache::PerformInitialLoad()
 				stubIslandRegion.size = size;
 				stubIslandRegion.prettyName = subCacheFilename + "::_stubs";
 				stubIslandRegion.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable | BNSegmentFlag::SegmentExecutable);
-				m_stubIslandRegions.push_back(stubIslandRegion);
+				MutableState().stubIslandRegions.push_back(std::move(stubIslandRegion));
 			}
 		}
 
@@ -718,10 +726,10 @@ void SharedCache::PerformInitialLoad()
 				mapRawToAddrAndSize.first = subCacheMapping.fileOffset;
 				mapRawToAddrAndSize.second.first = subCacheMapping.address;
 				mapRawToAddrAndSize.second.second = subCacheMapping.size;
-				subCache.mappings.push_back(mapRawToAddrAndSize);
+				subCache.mappings.push_back(std::move(mapRawToAddrAndSize));
 			}
 
-			m_backingCaches.push_back(subCache);
+			MutableState().backingCaches.push_back(std::move(subCache));
 		}
 		catch (...)
 		{}
@@ -741,7 +749,7 @@ void SharedCache::PerformInitialLoad()
 		m_logger->LogError("Failed to map VM pages for Shared Cache on initial load, this is fatal.");
 		return;
 	}
-	for (const auto &start : m_imageStarts)
+	for (const auto& start : State().imageStarts)
 	{
 		try {
 			auto imageHeader = SharedCache::LoadHeaderForAddress(vm, start.second, start.first);
@@ -752,7 +760,7 @@ void SharedCache::PerformInitialLoad()
 					auto mapping = vm->MappingAtAddress(imageHeader->linkeditSegment.vmaddr);
 					imageHeader->exportTriePath = mapping.first.filePath;
 				}
-				m_headers[start.second] = imageHeader.value();
+				MutableState().headers[start.second] = imageHeader.value();
 				CacheImage image;
 				image.installName = start.first;
 				image.headerLocation = start.second;
@@ -781,14 +789,14 @@ void SharedCache::PerformInitialLoad()
 
 					// if we're positive we have an entry point for some reason, force the segment
 					// executable. this helps with kernel images.
-					for (auto &entryPoint: imageHeader->m_entryPoints)
+					for (auto &entryPoint : imageHeader->m_entryPoints)
 						if (segment.vmaddr <= entryPoint && (entryPoint < (segment.vmaddr + segment.filesize)))
 							flags |= SegmentExecutable;
 
 					sectionRegion.flags = (BNSegmentFlag)flags;
 					image.regions.push_back(sectionRegion);
 				}
-				m_images.push_back(image);
+				MutableState().images.push_back(image);
 			}
 			else
 			{
@@ -801,9 +809,9 @@ void SharedCache::PerformInitialLoad()
 		}
 	}
 
-	m_logger->LogInfo("Loaded %d Mach-O headers", m_headers.size());
+	m_logger->LogInfo("Loaded %d Mach-O headers", State().headers.size());
 
-	for (const auto& cache : m_backingCaches)
+	for (const auto& cache : State().backingCaches)
 	{
 		size_t i = 0;
 		for (const auto& mapping : cache.mappings)
@@ -814,15 +822,15 @@ void SharedCache::PerformInitialLoad()
 			region.prettyName = base_name(cache.path) + "::" + std::to_string(i);
 			// FIXME flags!!! BackingCache.mapping needs refactored to store this information!
 			region.flags = (BNSegmentFlag)(BNSegmentFlag::SegmentReadable | BNSegmentFlag::SegmentExecutable);
-			m_nonImageRegions.push_back(region);
+			MutableState().nonImageRegions.push_back(std::move(region));
 			i++;
 		}
 	}
 
 	// Iterate through each Mach-O header
-	if (!m_dyldDataRegions.empty())
+	if (!State().dyldDataRegions.empty())
 	{
-		for (const auto& [headerKey, header] : m_headers)
+		for (const auto& [headerKey, header] : State().headers)
 		{
 			// Iterate through each segment of the header
 			for (const auto& segment : header.segments)
@@ -831,7 +839,7 @@ void SharedCache::PerformInitialLoad()
 				uint64_t segmentEnd = segmentStart + segment.vmsize;
 
 				// Iterate through each region in m_dyldDataRegions
-				for (auto it = m_dyldDataRegions.begin(); it != m_dyldDataRegions.end();)
+				for (auto it = State().dyldDataRegions.begin(); it != State().dyldDataRegions.end();)
 				{
 					uint64_t regionStart = it->start;
 					uint64_t regionSize = it->size;
@@ -864,12 +872,12 @@ void SharedCache::PerformInitialLoad()
 						}
 
 						// Erase the original region
-						it = m_dyldDataRegions.erase(it);
+						it = MutableState().dyldDataRegions.erase(it);
 
 						// Insert the new regions (if any)
 						for (const auto& newRegion : newRegions)
 						{
-							it = m_dyldDataRegions.insert(it, newRegion);
+							it = MutableState().dyldDataRegions.insert(it, newRegion);
 							++it;  // Move iterator to the next position
 						}
 					}
@@ -883,9 +891,9 @@ void SharedCache::PerformInitialLoad()
 	}
 
 	// Iterate through each Mach-O header
-	if (!m_nonImageRegions.empty())
+	if (!State().nonImageRegions.empty())
 	{
-		for (const auto& [headerKey, header] : m_headers)
+		for (const auto& [headerKey, header] : State().headers)
 		{
 			// Iterate through each segment of the header
 			for (const auto& segment : header.segments)
@@ -894,7 +902,7 @@ void SharedCache::PerformInitialLoad()
 				uint64_t segmentEnd = segmentStart + segment.vmsize;
 
 				// Iterate through each region in m_dyldDataRegions
-				for (auto it = m_nonImageRegions.begin(); it != m_nonImageRegions.end();)
+				for (auto it = State().nonImageRegions.begin(); it != State().nonImageRegions.end();)
 				{
 					uint64_t regionStart = it->start;
 					uint64_t regionSize = it->size;
@@ -927,12 +935,12 @@ void SharedCache::PerformInitialLoad()
 						}
 
 						// Erase the original region
-						it = m_nonImageRegions.erase(it);
+						it = MutableState().nonImageRegions.erase(it);
 
 						// Insert the new regions (if any)
 						for (const auto& newRegion : newRegions)
 						{
-							it = m_nonImageRegions.insert(it, newRegion);
+							it = MutableState().nonImageRegions.insert(it, newRegion);
 							++it;  // Move iterator to the next position
 						}
 					}
@@ -959,7 +967,7 @@ std::shared_ptr<VM> SharedCache::GetVMMap(bool mapPages)
 
 	if (mapPages)
 	{
-		for (const auto& cache : m_backingCaches)
+		for (const auto& cache : State().backingCaches)
 		{
 			for (const auto& mapping : cache.mappings)
 			{
@@ -980,22 +988,10 @@ void SharedCache::DeserializeFromRawView()
 	if (m_dscView->QueryMetadata(SharedCacheMetadataTag))
 	{
 		std::unique_lock<std::recursive_mutex> viewStateCacheLock(viewStateMutex);
-		if (viewStateCache.find(m_dscView->GetFile()->GetSessionId()) != viewStateCache.end())
+		if (auto it = viewStateCache.find(m_dscView->GetFile()->GetSessionId()); it != viewStateCache.end())
 		{
-			auto c = viewStateCache[m_dscView->GetFile()->GetSessionId()];
-			m_imageStarts = c.m_imageStarts;
-			m_cacheFormat = c.m_cacheFormat;
-			m_backingCaches = c.m_backingCaches;
-			m_viewState = c.m_viewState;
-			m_headers = c.m_headers;
-			m_images = c.m_images;
-			m_regionsMappedIntoMemory = c.m_regionsMappedIntoMemory;
-			m_stubIslandRegions = c.m_stubIslandRegions;
-			m_dyldDataRegions = c.m_dyldDataRegions;
-			m_nonImageRegions = c.m_nonImageRegions;
-			m_baseFilePath = c.m_baseFilePath;
-			m_exportInfos = c.m_exportInfos;
-			m_symbolInfos = c.m_symbolInfos;
+			m_state = it->second;
+			m_stateIsShared = true;
 			m_metadataValid = true;
 		}
 		else
@@ -1005,14 +1001,16 @@ void SharedCache::DeserializeFromRawView()
 		if (!m_metadataValid)
 		{
 			m_logger->LogError("Failed to deserialize Shared Cache metadata");
-			m_viewState = DSCViewStateUnloaded;
+			WillMutateState();
+			MutableState().viewState = DSCViewStateUnloaded;
 		}
 	}
 	else
 	{
 		m_metadataValid = true;
-		m_viewState = DSCViewStateUnloaded;
-		m_images.clear(); // fixme ??
+		WillMutateState();
+		MutableState().viewState = DSCViewStateUnloaded;
+		MutableState().images.clear();	// fixme ??
 	}
 }
 
@@ -1029,12 +1027,14 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 {
 	if (file->SlideInfoWasApplied())
 		return;
+
+	WillMutateState();
 	std::vector<std::pair<uint64_t, uint64_t>> rewrites;
 
 	dyld_cache_header baseHeader;
 	file->Read(&baseHeader, 0, sizeof(dyld_cache_header));
 	uint64_t base = UINT64_MAX;
-	for (const auto& backingCache : m_backingCaches)
+	for (const auto& backingCache : State().backingCaches)
 	{
 		for (const auto& mapping : backingCache.mappings)
 		{
@@ -1365,42 +1365,39 @@ SharedCache::SharedCache(BinaryNinja::Ref<BinaryNinja::BinaryView> dscView) : m_
 	DeserializeFromRawView();
 	if (!m_metadataValid)
 		return;
-	if (m_viewState == DSCViewStateUnloaded)
+	if (State().viewState == DSCViewStateUnloaded)
 	{
-		if (m_viewState == DSCViewStateUnloaded)
+		std::unique_lock<std::mutex> lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
+		try {
+			PerformInitialLoad();
+		}
+		catch (...)
 		{
-			std::unique_lock<std::mutex> lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
-			try {
-				PerformInitialLoad();
-			}
-			catch (...)
-			{
-				m_logger->LogError("Failed to perform initial load of Shared Cache");
-			}
+			m_logger->LogError("Failed to perform initial load of Shared Cache");
+		}
 
-			auto settings = m_dscView->GetLoadSettings(VIEW_NAME);
-			bool autoLoadLibsystem = true;
-			if (settings && settings->Contains("loader.dsc.autoLoadLibSystem"))
+		auto settings = m_dscView->GetLoadSettings(VIEW_NAME);
+		bool autoLoadLibsystem = true;
+		if (settings && settings->Contains("loader.dsc.autoLoadLibSystem"))
+		{
+			autoLoadLibsystem = settings->Get<bool>("loader.dsc.autoLoadLibSystem", m_dscView);
+		}
+		if (autoLoadLibsystem)
+		{
+			for (const auto& [_, header] : State().headers)
 			{
-				autoLoadLibsystem = settings->Get<bool>("loader.dsc.autoLoadLibSystem", m_dscView);
-			}
-			if (autoLoadLibsystem)
-			{
-				for (const auto& [_, header] : m_headers)
+				if (header.installName.find("libsystem_c.dylib") != std::string::npos)
 				{
-					if (header.installName.find("libsystem_c.dylib") != std::string::npos)
-					{
-						lock.unlock();
-						m_logger->LogInfo("Loading core libsystem_c.dylib library");
-						LoadImageWithInstallName(header.installName);
-						lock.lock();
-						break;
-					}
+					lock.unlock();
+					m_logger->LogInfo("Loading core libsystem_c.dylib library");
+					LoadImageWithInstallName(header.installName);
+					lock.lock();
+					break;
 				}
 			}
-			m_viewState = DSCViewStateLoaded;
-			SaveToDSCView();
 		}
+		MutableState().viewState = DSCViewStateLoaded;
+		SaveToDSCView();
 	}
 	else
 	{
@@ -1430,7 +1427,7 @@ SharedCache* SharedCache::GetFromDSCView(BinaryNinja::Ref<BinaryNinja::BinaryVie
 
 std::optional<uint64_t> SharedCache::GetImageStart(std::string installName)
 {
-	for (const auto& [name, start] : m_imageStarts)
+	for (const auto& [name, start] : State().imageStarts)
 	{
 		if (name == installName)
 		{
@@ -1445,7 +1442,7 @@ std::optional<SharedCacheMachOHeader> SharedCache::HeaderForAddress(uint64_t add
 	// We _could_ mark each page with the image start? :grimacing emoji:
 	// But that'd require mapping pages :grimacing emoji: :grimacing emoji:
 	// There's not really any other hacks that could make this faster, that I can think of...
-	for (const auto& [start, header] : m_headers)
+	for (const auto& [start, header] : State().headers)
 	{
 		for (const auto& segment : header.segments)
 		{
@@ -1460,21 +1457,21 @@ std::optional<SharedCacheMachOHeader> SharedCache::HeaderForAddress(uint64_t add
 
 std::string SharedCache::NameForAddress(uint64_t address)
 {
-	for (const auto& stubIsland : m_stubIslandRegions)
+	for (const auto& stubIsland : State().stubIslandRegions)
 	{
 		if (stubIsland.start <= address && stubIsland.start + stubIsland.size > address)
 		{
 			return stubIsland.prettyName;
 		}
 	}
-	for (const auto& dyldData : m_dyldDataRegions)
+	for (const auto& dyldData : State().dyldDataRegions)
 	{
 		if (dyldData.start <= address && dyldData.start + dyldData.size > address)
 		{
 			return dyldData.prettyName;
 		}
 	}
-	for (const auto& nonImageRegion : m_nonImageRegions)
+	for (const auto& nonImageRegion : State().nonImageRegions)
 	{
 		if (nonImageRegion.start <= address && nonImageRegion.start + nonImageRegion.size > address)
 		{
@@ -1508,7 +1505,7 @@ std::string SharedCache::ImageNameForAddress(uint64_t address)
 
 bool SharedCache::LoadImageContainingAddress(uint64_t address)
 {
-	for (const auto& [start, header] : m_headers)
+	for (const auto& [start, header] : State().headers)
 	{
 		for (const auto& segment : header.segments)
 		{
@@ -1526,6 +1523,8 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 {
 	std::unique_lock<std::mutex> lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
 	DeserializeFromRawView();
+	WillMutateState();
+
 	auto vm = GetVMMap();
 	if (!vm)
 	{
@@ -1537,13 +1536,13 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 	CacheImage* targetImage = nullptr;
 	MemoryRegion* targetSegment = nullptr;
 
-	for (auto& image : m_images)
+	for (auto& image : MutableState().images)
 	{
 		for (auto& region : image.regions)
 		{
 			if (region.start <= address && region.start + region.size > address)
 			{
-				targetHeader = m_headers[image.headerLocation];
+				targetHeader = MutableState().headers[image.headerLocation];
 				targetImage = &image;
 				targetSegment = &region;
 				break;
@@ -1554,7 +1553,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 	}
 	if (!targetSegment)
 	{
-		for (auto& stubIsland : m_stubIslandRegions)
+		for (auto& stubIsland : MutableState().stubIslandRegions)
 		{
 			if (stubIsland.start <= address && stubIsland.start + stubIsland.size > address)
 			{
@@ -1583,7 +1582,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				stubIsland.rawViewOffsetIfLoaded = rawViewEnd;
 
-				m_regionsMappedIntoMemory.push_back(stubIsland);
+				MutableState().regionsMappedIntoMemory.push_back(stubIsland);
 
 				SaveToDSCView();
 
@@ -1594,7 +1593,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 			}
 		}
 
-		for (auto& dyldData : m_dyldDataRegions)
+		for (auto& dyldData : MutableState().dyldDataRegions)
 		{
 			if (dyldData.start <= address && dyldData.start + dyldData.size > address)
 			{
@@ -1622,7 +1621,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 				dyldData.loaded = true;
 				dyldData.rawViewOffsetIfLoaded = rawViewEnd;
 
-				m_regionsMappedIntoMemory.push_back(dyldData);
+				MutableState().regionsMappedIntoMemory.push_back(dyldData);
 
 				SaveToDSCView();
 
@@ -1633,7 +1632,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 			}
 		}
 
-		for (auto& region : m_nonImageRegions)
+		for (auto& region : MutableState().nonImageRegions)
 		{
 			if (region.start <= address && region.start + region.size > address)
 			{
@@ -1660,7 +1659,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 				region.loaded = true;
 				region.rawViewOffsetIfLoaded = rawViewEnd;
 
-				m_regionsMappedIntoMemory.push_back(region);
+				MutableState().regionsMappedIntoMemory.push_back(region);
 
 				SaveToDSCView();
 
@@ -1696,7 +1695,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 	targetSegment->loaded = true;
 	targetSegment->rawViewOffsetIfLoaded = rawViewEnd;
 
-	m_regionsMappedIntoMemory.push_back(*targetSegment);
+	MutableState().regionsMappedIntoMemory.push_back(*targetSegment);
 
 	SaveToDSCView();
 
@@ -1720,12 +1719,14 @@ bool SharedCache::LoadImageWithInstallName(std::string installName)
 	std::unique_lock<std::mutex> lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
 
 	DeserializeFromRawView();
+	WillMutateState();
+
 	m_logger->LogInfo("Loading image %s", installName.c_str());
 
 	auto vm = GetVMMap();
 	CacheImage* targetImage = nullptr;
 
-	for (auto& cacheImage : m_images)
+	for (auto& cacheImage : MutableState().images)
 	{
 		if (cacheImage.installName == installName)
 		{
@@ -1733,11 +1734,15 @@ bool SharedCache::LoadImageWithInstallName(std::string installName)
 			break;
 		}
 	}
-
-	auto header = m_headers[targetImage->headerLocation];
+	auto it = State().headers.find(targetImage->headerLocation);
+	if (it == State().headers.end())
+	{
+		return false;
+	}
+	const auto& header = it->second;
 
 	auto id = m_dscView->BeginUndoActions();
-	m_viewState = DSCViewStateLoadedWithImages;
+	MutableState().viewState = DSCViewStateLoadedWithImages;
 
 	auto reader = VMReader(vm);
 	reader.Seek(targetImage->headerLocation);
@@ -1770,7 +1775,7 @@ bool SharedCache::LoadImageWithInstallName(std::string installName)
 		region.loaded = true;
 		region.rawViewOffsetIfLoaded = rawViewEnd;
 
-		m_regionsMappedIntoMemory.push_back(region);
+		MutableState().regionsMappedIntoMemory.push_back(region);
 
 		m_dscView->GetParentView()->AddAutoSegment(rawViewEnd, region.size, rawViewEnd, region.size, region.flags);
 		m_dscView->AddUserSegment(region.start, region.size, rawViewEnd, region.size, region.flags);
@@ -2260,6 +2265,7 @@ std::optional<SharedCacheMachOHeader> SharedCache::LoadHeaderForAddress(std::sha
 void SharedCache::InitializeHeader(
 	Ref<BinaryView> view, VM* vm, SharedCacheMachOHeader header, std::vector<MemoryRegion*> regionsToLoad)
 {
+	WillMutateState();
 
 	Ref<Settings> settings = view->GetLoadSettings(VIEW_NAME);
 	bool applyFunctionStarts = true;
@@ -2629,7 +2635,7 @@ void SharedCache::InitializeHeader(
 				view->DefineAutoSymbol(symbolObj);
 			symbolInfos.push_back({sym.n_value, {type, symbol}});
 		}
-		m_symbolInfos[header.textBase] = symbolInfos;
+		MutableState().symbolInfos[header.textBase] = symbolInfos;
 	}
 
 	if (header.exportTriePresent && header.linkeditPresent && vm->AddressIsMapped(header.linkeditSegment.vmaddr))
@@ -2675,7 +2681,7 @@ void SharedCache::InitializeHeader(
 			else
 				view->DefineAutoSymbol(symbol);
 		}
-		m_exportInfos[header.textBase] = exportMapping;
+		MutableState().exportInfos[header.textBase] = std::move(exportMapping);
 	}
 	view->EndBulkModifySymbols();
 
@@ -2782,7 +2788,7 @@ std::vector<Ref<Symbol>> SharedCache::ParseExportTrie(std::shared_ptr<MMappedFil
 std::vector<std::string> SharedCache::GetAvailableImages()
 {
 	std::vector<std::string> installNames;
-	for (const auto& header : m_headers)
+	for (const auto& header : State().headers)
 	{
 		installNames.push_back(header.second.installName);
 	}
@@ -2792,10 +2798,12 @@ std::vector<std::string> SharedCache::GetAvailableImages()
 
 std::vector<std::pair<std::string, Ref<Symbol>>> SharedCache::LoadAllSymbolsAndWait()
 {
+	WillMutateState();
+
 	std::unique_lock<std::mutex> initialLoadBlock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
 
 	std::vector<std::pair<std::string, Ref<Symbol>>> symbols;
-	for (const auto& img : m_images)
+	for (const auto& img : State().images)
 	{
 		auto header = HeaderForAddress(img.headerLocation);
 		std::shared_ptr<MMappedFileAccessor> mapping;
@@ -2814,7 +2822,7 @@ std::vector<std::pair<std::string, Ref<Symbol>>> SharedCache::LoadAllSymbolsAndW
 			exportMapping.push_back({sym->GetAddress(), {sym->GetType(), sym->GetRawName()}});
 			symbols.push_back({img.installName, sym});
 		}
-		m_exportInfos[header->textBase] = exportMapping;
+		MutableState().exportInfos[header->textBase] = std::move(exportMapping);
 	}
 
 	SaveToDSCView();
@@ -2836,17 +2844,22 @@ std::string SharedCache::SerializedImageHeaderForAddress(uint64_t address)
 
 std::string SharedCache::SerializedImageHeaderForName(std::string name)
 {
-	auto header = HeaderForAddress(m_imageStarts[name]);
-	if (header)
+	if (auto it = State().imageStarts.find(name); it != State().imageStarts.end())
 	{
-		return header->AsString();
+		if (auto header = HeaderForAddress(it->second))
+		{
+			return header->AsString();
+		}
 	}
 	return "";
 }
 
 
-void SharedCache::FindSymbolAtAddrAndApplyToAddr(uint64_t symbolLocation, uint64_t targetLocation, bool triggerReanalysis)
+void SharedCache::FindSymbolAtAddrAndApplyToAddr(
+	uint64_t symbolLocation, uint64_t targetLocation, bool triggerReanalysis)
 {
+	WillMutateState();
+
 	std::string prefix = "";
 	if (symbolLocation != targetLocation)
 		prefix = "j_";
@@ -2933,7 +2946,7 @@ void SharedCache::FindSymbolAtAddrAndApplyToAddr(uint64_t symbolLocation, uint64
 		}
 		{
 			std::unique_lock<std::mutex> _lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
-			m_exportInfos[header->textBase] = exportMapping;
+			MutableState().exportInfos[header->textBase] = std::move(exportMapping);
 		}
 		m_dscView->EndBulkModifySymbols();
 		m_dscView->ForgetUndoActions(id);
@@ -2948,22 +2961,16 @@ bool SharedCache::SaveToDSCView()
 		auto data = AsMetadata();
 		m_dscView->StoreMetadata(SharedCacheMetadataTag, data);
 		m_dscView->GetParentView()->GetParentView()->StoreMetadata(SharedCacheMetadataTag, data);
+
+		// By moving our state the to cache we can avoid creating a copy in the case
+		// that no further mutations are made to `this`. If we're not done being mutated,
+		// the data will be copied on the first mutation.
+		auto cachedState = std::make_shared<struct State>(std::move(*m_state));
+		m_state = cachedState;
+		m_stateIsShared = true;
+
 		std::unique_lock<std::recursive_mutex> viewStateCacheLock(viewStateMutex);
-		ViewStateCacheStore c;
-		c.m_imageStarts = m_imageStarts;
-		c.m_cacheFormat = m_cacheFormat;
-		c.m_backingCaches = m_backingCaches;
-		c.m_viewState = m_viewState;
-		c.m_headers = m_headers;
-		c.m_images = m_images;
-		c.m_regionsMappedIntoMemory = m_regionsMappedIntoMemory;
-		c.m_stubIslandRegions = m_stubIslandRegions;
-		c.m_dyldDataRegions = m_dyldDataRegions;
-		c.m_nonImageRegions = m_nonImageRegions;
-		c.m_baseFilePath = m_baseFilePath;
-		c.m_exportInfos = m_exportInfos;
-		c.m_symbolInfos = m_symbolInfos;
-		viewStateCache[m_dscView->GetFile()->GetSessionId()] = c;
+		viewStateCache[m_dscView->GetFile()->GetSessionId()] = std::move(cachedState);
 
 		m_metadataValid = true;
 
@@ -2974,7 +2981,7 @@ bool SharedCache::SaveToDSCView()
 std::vector<MemoryRegion> SharedCache::GetMappedRegions() const
 {
 	std::unique_lock<std::mutex> lock(viewSpecificMutexes[m_dscView->GetFile()->GetSessionId()].viewOperationsThatInfluenceMetadataMutex);
-	return m_regionsMappedIntoMemory;
+	return State().regionsMappedIntoMemory;
 }
 
 extern "C"
@@ -3120,7 +3127,7 @@ extern "C"
 	{
 		if (cache->object)
 		{
-			return (BNDSCViewState)cache->object->State();
+			return (BNDSCViewState)cache->object->ViewState();
 		}
 
 		return BNDSCViewState::Unloaded;
@@ -3327,14 +3334,14 @@ void SharedCache::Store(SerializationContext& context) const
 {
 	Serialize(context, "metadataVersion", METADATA_VERSION);
 
-	MSS(m_viewState);
-	MSS_CAST(m_cacheFormat, uint8_t);
-	MSS(m_imageStarts);
-	MSS(m_baseFilePath);
+    Serialize(context, "m_viewState", State().viewState);
+    Serialize(context, "m_cacheFormat", State().cacheFormat);
+    Serialize(context, "m_imageStarts", State().imageStarts);
+    Serialize(context, "m_baseFilePath", State().baseFilePath);
 
 	Serialize(context, "headers");
 	context.writer.StartArray();
-	for (auto& [k, v] : m_headers)
+	for (auto& [k, v] : State().headers)
 	{
 		context.writer.StartObject();
 		v.Store(context);
@@ -3344,7 +3351,7 @@ void SharedCache::Store(SerializationContext& context) const
 
 	Serialize(context, "exportInfos");
 	context.writer.StartArray();
-	for (const auto& pair1 : m_exportInfos)
+	for (const auto& pair1 : State().exportInfos)
 	{
 		context.writer.StartObject();
 		Serialize(context, "key", pair1.first);
@@ -3363,12 +3370,12 @@ void SharedCache::Store(SerializationContext& context) const
 	}
 	context.writer.EndArray();
 
-	Serialize(context, "backingCaches", m_backingCaches);
-	Serialize(context, "stubIslands", m_stubIslandRegions);
-	Serialize(context, "images", m_images);
-	Serialize(context, "regionsMappedIntoMemory", m_regionsMappedIntoMemory);
-	Serialize(context, "dyldDataSections", m_dyldDataRegions);
-	Serialize(context, "nonImageRegions", m_nonImageRegions);
+	Serialize(context, "backingCaches", State().backingCaches);
+	Serialize(context, "stubIslands", State().stubIslandRegions);
+	Serialize(context, "images", State().images);
+	Serialize(context, "regionsMappedIntoMemory", State().regionsMappedIntoMemory);
+	Serialize(context, "dyldDataSections", State().dyldDataRegions);
+	Serialize(context, "nonImageRegions", State().nonImageRegions);
 }
 
 void SharedCache::Load(DeserializationContext& context)
@@ -3386,18 +3393,23 @@ void SharedCache::Load(DeserializationContext& context)
 		m_logger->LogError("Shared Cache metadata version missing");
 		return;
 	}
-	m_viewState = MSL_CAST(m_viewState, uint8_t, DSCViewState);
-	m_cacheFormat = MSL_CAST(m_cacheFormat, uint8_t, SharedCacheFormat);
-	m_headers.clear();
+
+	m_stateIsShared = false;
+	m_state = std::make_shared<struct SharedCache::State>();
+
+	MutableState().viewState = static_cast<DSCViewState>(context.load<uint8_t>("m_viewState"));
+	MutableState().cacheFormat = static_cast<SharedCacheFormat>(context.load<uint8_t>("m_cacheFormat"));
+
 	for (auto& startAndHeader : context.doc["headers"].GetArray())
 	{
 		SharedCacheMachOHeader header;
 		header.LoadFromValue(startAndHeader);
-		m_headers[header.textBase] = header;
+		MutableState().headers[header.textBase] = std::move(header);
 	}
-	MSL(m_imageStarts);
-	MSL(m_baseFilePath);
-	m_exportInfos.clear();
+
+	Deserialize(context, "m_imageStarts", MutableState().imageStarts);
+	Deserialize(context, "m_baseFilePath", MutableState().baseFilePath);
+
 	for (const auto& obj1 : context.doc["exportInfos"].GetArray())
 	{
 		std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>> innerVec;
@@ -3408,9 +3420,9 @@ void SharedCache::Load(DeserializationContext& context)
 			innerVec.push_back({obj2["key"].GetUint64(), innerPair});
 		}
 
-		m_exportInfos[obj1["key"].GetUint64()] = innerVec;
+		MutableState().exportInfos[obj1["key"].GetUint64()] = std::move(innerVec);
 	}
-	m_symbolInfos.clear();
+
 	for (auto& symbolInfo : context.doc["symbolInfos"].GetArray())
 	{
 		std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>> symbolInfoVec;
@@ -3419,52 +3431,94 @@ void SharedCache::Load(DeserializationContext& context)
 			symbolInfoVec.push_back({symbolInfoPair[0].GetUint64(),
 				{(BNSymbolType)symbolInfoPair[1].GetUint(), symbolInfoPair[2].GetString()}});
 		}
-		m_symbolInfos[symbolInfo[0].GetUint64()] = std::move(symbolInfoVec);
+		MutableState().symbolInfos[symbolInfo[0].GetUint64()] = std::move(symbolInfoVec);
 	}
-	m_backingCaches.clear();
+
 	for (auto& bcV : context.doc["backingCaches"].GetArray())
 	{
 		BackingCache bc;
 		bc.LoadFromValue(bcV);
-		m_backingCaches.push_back(std::move(bc));
+		MutableState().backingCaches.push_back(std::move(bc));
 	}
-	m_images.clear();
+
 	for (auto& imgV : context.doc["images"].GetArray())
 	{
 		CacheImage img;
 		img.LoadFromValue(imgV);
-		m_images.push_back(std::move(img));
+		MutableState().images.push_back(std::move(img));
 	}
-	m_regionsMappedIntoMemory.clear();
+
 	for (auto& rV : context.doc["regionsMappedIntoMemory"].GetArray())
 	{
 		MemoryRegion r;
 		r.LoadFromValue(rV);
-		m_regionsMappedIntoMemory.push_back(std::move(r));
+		MutableState().regionsMappedIntoMemory.push_back(std::move(r));
 	}
-	m_stubIslandRegions.clear();
+
 	for (auto& siV : context.doc["stubIslands"].GetArray())
 	{
 		MemoryRegion si;
 		si.LoadFromValue(siV);
-		m_stubIslandRegions.push_back(std::move(si));
+		MutableState().stubIslandRegions.push_back(std::move(si));
 	}
-	m_dyldDataRegions.clear();
+
 	for (auto& siV : context.doc["dyldDataSections"].GetArray())
 	{
 		MemoryRegion si;
 		si.LoadFromValue(siV);
-		m_dyldDataRegions.push_back(std::move(si));
+		MutableState().dyldDataRegions.push_back(std::move(si));
 	}
-	m_nonImageRegions.clear();
+
 	for (auto& siV : context.doc["nonImageRegions"].GetArray())
 	{
 		MemoryRegion si;
 		si.LoadFromValue(siV);
-		m_nonImageRegions.push_back(std::move(si));
+		MutableState().nonImageRegions.push_back(std::move(si));
 	}
 
 	m_metadataValid = true;
+}
+
+__attribute__((always_inline)) void SharedCache::AssertMutable() const
+{
+	if (m_stateIsShared)
+	{
+		abort();
+	}
+}
+
+void SharedCache::WillMutateState()
+{
+	if (!m_state)
+	{
+		m_state = std::make_shared<struct State>();
+	}
+	else if (m_stateIsShared)
+	{
+		m_state = std::make_shared<struct State>(*m_state);
+	}
+	m_stateIsShared = false;
+}
+
+
+const std::vector<BackingCache>& SharedCache::BackingCaches() const
+{
+	return State().backingCaches;
+}
+
+DSCViewState SharedCache::ViewState() const
+{
+	return State().viewState;
+}
+
+const std::unordered_map<std::string, uint64_t>& SharedCache::AllImageStarts() const
+{
+	return State().imageStarts;
+}
+
+const std::unordered_map<uint64_t, SharedCacheMachOHeader>& SharedCache::AllImageHeaders() const
+{
+	return State().headers;
 }
 
 }  // namespace SharedCacheCore

--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -917,21 +917,19 @@ void SharedCache::PerformInitialLoad()
 						// Part before the overlap
 						if (regionStart < segmentStart)
 						{
-							MemoryRegion newRegion;
+							MemoryRegion newRegion(*it);
 							newRegion.start = regionStart;
 							newRegion.size = segmentStart - regionStart;
-							newRegion.prettyName = it->prettyName;
-							newRegions.push_back(newRegion);
+							newRegions.push_back(std::move(newRegion));
 						}
 
 						// Part after the overlap
 						if (regionEnd > segmentEnd)
 						{
-							MemoryRegion newRegion;
+							MemoryRegion newRegion(*it);
 							newRegion.start = segmentEnd;
 							newRegion.size = regionEnd - segmentEnd;
-							newRegion.prettyName = it->prettyName;
-							newRegions.push_back(newRegion);
+							newRegions.push_back(std::move(newRegion));
 						}
 
 						// Erase the original region

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -8,6 +8,10 @@
 #include "view/macho/machoview.h"
 #include "MetadataSerializable.hpp"
 #include "../api/sharedcachecore.h"
+#include "immer/map.hpp" 
+#include "immer/vector.hpp" 
+#include "immer/vector_transient.hpp" 
+#include "immer/map_transient.hpp" 
 
 #ifndef SHAREDCACHE_SHAREDCACHE_H
 #define SHAREDCACHE_SHAREDCACHE_H
@@ -61,7 +65,7 @@ namespace SharedCacheCore {
 	{
 		std::string installName;
 		uint64_t headerLocation;
-		std::vector<MemoryRegion> regions;
+		immer::vector<MemoryRegion> regions;
 
 		void Store(SerializationContext& context) const
 		{
@@ -81,13 +85,14 @@ namespace SharedCacheCore {
 			MSL(installName);
 			MSL(headerLocation);
 			auto bArr = context.doc["regions"].GetArray();
-			regions.clear();
+			auto local_regions = immer::vector_transient<MemoryRegion>();
 			for (auto& region : bArr)
 			{
 				MemoryRegion r;
 				r.LoadFromString(region.GetString());
-				regions.push_back(r);
+				local_regions.push_back(r);
 			}
+			regions = local_regions.persistent();
 		}
 	};
 
@@ -95,7 +100,7 @@ namespace SharedCacheCore {
 	{
 		std::string path;
 		bool isPrimary = false;
-		std::vector<std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> mappings;
+		immer::vector<std::pair<uint64_t, std::pair<uint64_t, uint64_t>>> mappings;
 
 		void Store(SerializationContext& context) const
 		{
@@ -361,36 +366,36 @@ namespace SharedCacheCore {
 	{
 		uint64_t textBase = 0;
 		uint64_t loadCommandOffset = 0;
-		mach_header_64 ident;
+		mach_header_64 ident {};
 		std::string identifierPrefix;
 		std::string installName;
 
-		std::vector<std::pair<uint64_t, bool>> entryPoints;
-		std::vector<uint64_t> m_entryPoints;  // list of entrypoints
+		immer::vector<std::pair<uint64_t, bool>> entryPoints;
+		immer::vector<uint64_t> m_entryPoints;  // list of entrypoints
 
-		symtab_command symtab;
-		dysymtab_command dysymtab;
-		dyld_info_command dyldInfo;
-		routines_command_64 routines64;
-		function_starts_command functionStarts;
-		std::vector<section_64> moduleInitSections;
-		linkedit_data_command exportTrie;
+		symtab_command symtab {};
+		dysymtab_command dysymtab {};
+		dyld_info_command dyldInfo {};
+		routines_command_64 routines64 {};
+		function_starts_command functionStarts {};
+		immer::vector<section_64> moduleInitSections;
+		linkedit_data_command exportTrie {};
 		linkedit_data_command chainedFixups {};
 
 		uint64_t relocationBase;
 		// Section and program headers, internally use 64-bit form as it is a superset of 32-bit
-		std::vector<segment_command_64> segments;  // only three types of sections __TEXT, __DATA, __IMPORT
-		segment_command_64 linkeditSegment;
-		std::vector<section_64> sections;
-		std::vector<std::string> sectionNames;
+		immer::vector<segment_command_64> segments;  // only three types of sections __TEXT, __DATA, __IMPORT
+		segment_command_64 linkeditSegment {};
+		immer::vector<section_64> sections;
+		immer::vector<std::string> sectionNames;
 
-		std::vector<section_64> symbolStubSections;
-		std::vector<section_64> symbolPointerSections;
+		immer::vector<section_64> symbolStubSections;
+		immer::vector<section_64> symbolPointerSections;
 
-		std::vector<std::string> dylibs;
+		immer::vector<std::string> dylibs;
 
-		build_version_command buildVersion;
-		std::vector<build_tool_version> buildToolVersions;
+		build_version_command buildVersion {};
+		immer::vector<build_tool_version> buildToolVersions;
 
 		std::string exportTriePath;
 
@@ -572,19 +577,19 @@ namespace SharedCacheCore {
 		std::string ImageNameForAddress(uint64_t address);
 		std::vector<std::string> GetAvailableImages();
 
-		std::vector<MemoryRegion> GetMappedRegions() const;
+		immer::vector<MemoryRegion> GetMappedRegions() const;
 
 		std::vector<std::pair<std::string, Ref<Symbol>>> LoadAllSymbolsAndWait();
 
-		const std::unordered_map<std::string, uint64_t>& AllImageStarts() const;
-		const std::unordered_map<uint64_t, SharedCacheMachOHeader>& AllImageHeaders() const;
+		const immer::map<std::string, uint64_t>& AllImageStarts() const;
+		const immer::map<uint64_t, SharedCacheMachOHeader>& AllImageHeaders() const;
 
 		std::string SerializedImageHeaderForAddress(uint64_t address);
 		std::string SerializedImageHeaderForName(std::string name);
 
 		void FindSymbolAtAddrAndApplyToAddr(uint64_t symbolLocation, uint64_t targetLocation, bool triggerReanalysis);
 
-		const std::vector<BackingCache>& BackingCaches() const;
+		const immer::vector<BackingCache>& BackingCaches() const;
 
 		DSCViewState ViewState() const;
 
@@ -594,7 +599,7 @@ namespace SharedCacheCore {
 		std::optional<SharedCacheMachOHeader> LoadHeaderForAddress(
 			std::shared_ptr<VM> vm, uint64_t address, std::string installName);
 		void InitializeHeader(
-			Ref<BinaryView> view, VM* vm, SharedCacheMachOHeader header, std::vector<MemoryRegion*> regionsToLoad);
+			Ref<BinaryView> view, VM* vm, SharedCacheMachOHeader header, const std::vector<const MemoryRegion*> regionsToLoad);
 		void ReadExportNode(std::vector<Ref<Symbol>>& symbolList, SharedCacheMachOHeader& header, DataBuffer& buffer,
 			uint64_t textBase, const std::string& currentText, size_t cursor, uint32_t endGuard);
 		std::vector<Ref<Symbol>> ParseExportTrie(

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -564,7 +564,7 @@ namespace SharedCacheCore {
 
 		void ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAccessor> file);
 		std::optional<uint64_t> GetImageStart(std::string installName);
-		std::optional<SharedCacheMachOHeader> HeaderForAddress(uint64_t);
+		const SharedCacheMachOHeader* HeaderForAddress(uint64_t);
 		bool LoadImageWithInstallName(std::string installName);
 		bool LoadSectionAtAddress(uint64_t address);
 		bool LoadImageContainingAddress(uint64_t address);

--- a/view/sharedcache/core/VM.h
+++ b/view/sharedcache/core/VM.h
@@ -6,6 +6,7 @@
 #define SHAREDCACHE_VM_H
 #include <binaryninjaapi.h>
 #include <condition_variable>
+#include <unordered_map>
 
 void VMShutdown();
 
@@ -215,7 +216,7 @@ class VMReader;
 
 
 class VM {
-    std::map<size_t, PageMapping> m_map;
+    std::unordered_map<size_t, PageMapping> m_map;
     size_t m_pageSize;
     size_t m_pageSizeBits;
     bool m_safe;

--- a/view/sharedcache/ui/dsctriage.cpp
+++ b/view/sharedcache/ui/dsctriage.cpp
@@ -448,7 +448,6 @@ QVariant SymbolTableModel::headerData(int section, Qt::Orientation orientation, 
 }
 
 void SymbolTableModel::updateSymbols() {
-	m_symbols = m_parent->m_symbols;
 	setFilter(m_filter);
 }
 

--- a/view/sharedcache/workflow/CMakeLists.txt
+++ b/view/sharedcache/workflow/CMakeLists.txt
@@ -65,7 +65,7 @@ message(STATUS "RCD: ${BN_REF_COUNT_DEBUG}")
 get_recursive_include_dirs(binaryninjaapi INCLUDES)
 
 target_include_directories(sharedcacheworkflow
-        PUBLIC ${PROJECT_SOURCE_DIR} ${INCLUDES})
+        PUBLIC ${PROJECT_SOURCE_DIR} ${INCLUDES} ${BN_API_PATH}/vendor/immer)
 
 set_target_properties(sharedcacheworkflow PROPERTIES
         CXX_STANDARD 17


### PR DESCRIPTION
There were a couple of issues with serialization causing assertion crashes. With these commits AFAICT the DSC can be saved to a .bndb and then that .bndb can be loaded again without any crashes. There still seem to be issues with doing that in a project if Binary Ninja is reloaded inbetween, but for a standalone .bndb it works fine.