### PR TITLE
[SharedCache] Set cache state when loading from string in `SharedCache::DeserializeFromRawView`

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -1065,6 +1065,15 @@ void SharedCache::DeserializeFromRawView()
 		else
 		{
 			LoadFromString(m_dscView->GetStringMetadata(SharedCacheMetadataTag));
+
+			if (m_metadataValid)
+			{
+				cachedState = std::make_shared<struct State>(std::move(*m_state));
+				m_state = cachedState;
+				m_stateIsShared = true;
+
+				m_viewSpecificState->SetCachedState(std::move(cachedState));
+			}
 		}
 		if (!m_metadataValid)
 		{


### PR DESCRIPTION
In the case where Binary Ninja has just been opened and a .bndb file is opened for DSC, there will be no cached state. If the user does not do anything to trigger execution of `SharedCache::SaveToDSCView`, which requires loading a section, image or symbols, then the state will never be cached in the view specific state cache. This can commonly happen as after initial loading of required DSC libraries the user maybe unlikely to do the same again in the future.

The problem with this is that the DSC plugin API creates a new instance of `SharedCache` each time its called into. Each time that occurs, if there is no cached state, the metadata stored in the database must be deserialized. This can be incredibly slow when 10s of images have been loaded from DSC. This code path is triggered everytime the user right-clicks (in linear view at least) and can cause the UI to freeze for over 10 seconds each time, again, depending on the number of images loaded.

This commit fixes the problem by caching the state when it is initially deserialized for the first time in `SharedCache::DeserializeFromRawView`. This occurs during initial loading of a DSC database so as soon as its loaded, right-clicking won't cause the UI to freeze at all. This likely benefits other areas of UI interactivity as well.

---

At this point its getting harder and harder to do pull requests against the Vector35 repo because of all the changes, and then also porting it to this branch which I use, so I'm just going to start doing them directly against this branch to make things easier.